### PR TITLE
Add `--file` multipart upload support to `actions run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ holded help
 - `holded actions list`
 - `holded actions describe <action-id|operation-id>`
 - `holded actions run <action-id|operation-id>`
+- `holded actions run invoice.attach-file --path docType=purchase --path documentId=<id> --file ./ticket.jpg`
 
 ## Action Catalog (for skills)
 
@@ -124,6 +125,12 @@ holded actions run invoice.list-contacts
 
 # run an action by operation id with path/query params
 holded actions run "Get Contact" --path contactId=abc123 --query customId=my-ref
+
+# run an action with multipart file upload
+holded actions run invoice.attach-file \
+  --path docType=purchase \
+  --path documentId=abc123 \
+  --file ./ticket.jpg
 
 # machine-readable output
 holded actions run invoice.list-contacts --json


### PR DESCRIPTION
## Summary
- add a new `--file` flag to `holded actions run` to send multipart/form-data uploads using field name `file`
- keep existing JSON body behavior unchanged and reject invalid combinations (`--file` with `--body`/`--body-file`)
- set `Content-Type` automatically for multipart uploads via generated boundary
- update CLI usage/help and README examples for `invoice.attach-file`
- add integration tests for successful multipart upload and argument validation

## Why
Issue #1 reports that `invoice.attach-file` fails with `File not found` because the CLI only sent JSON bodies. This change enables file upload flow required by Holded's attachment endpoint.

## Validation
- `go test ./internal/cli ./internal/holded`
- `go test ./...`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69921e780e48832ba918c26a4ae1781d)